### PR TITLE
Fix for iOS build failure in SPI

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,3 +3,4 @@ builder:
   configs:
     - platform: ios
       documentation_targets: [SectionUI]
+      scheme: SectionKit

--- a/.spi.yml
+++ b/.spi.yml
@@ -3,4 +3,4 @@ builder:
   configs:
     - platform: ios
       documentation_targets: [SectionUI]
-      scheme: SectionKit
+      scheme: SectionUI


### PR DESCRIPTION
This should fix the build error in SPI for the iOS build:

https://swiftpackageindex.com/linhay/SectionKit/builds

![CleanShot 2023-03-20 at 14 10 00@2x](https://user-images.githubusercontent.com/65520/226348617-bc8e0ac0-e5cf-41d0-9fda-c65672271b71.png)
